### PR TITLE
fix / ImageLoader.Load() が想定通りの動作をするよう実装

### DIFF
--- a/ImageChecker/Models/ImageLoader.cs
+++ b/ImageChecker/Models/ImageLoader.cs
@@ -38,10 +38,10 @@
         {
             List<string> fileNames = Directory.GetFiles(directoryPath, "*.png").Concat(Directory.GetFiles(directoryPath, "*.jpg")).ToList();
 
-            ImageFilesA = fileNames.Where(name => name.Contains("A")).Select(name => new ImageFile(name)).ToList();
-            ImageFilesB = fileNames.Where(name => name.Contains("B")).Select(name => new ImageFile(name)).ToList();
-            ImageFilesC = fileNames.Where(name => name.Contains("C")).Select(name => new ImageFile(name)).ToList();
-            ImageFilesD = fileNames.Where(name => name.Contains("D")).Select(name => new ImageFile(name)).ToList();
+            ImageFilesA = fileNames.Where(name => Path.GetFileName(name).Contains("A")).Select(name => new ImageFile(name)).ToList();
+            ImageFilesB = fileNames.Where(name => Path.GetFileName(name).Contains("B")).Select(name => new ImageFile(name)).ToList();
+            ImageFilesC = fileNames.Where(name => Path.GetFileName(name).Contains("C")).Select(name => new ImageFile(name)).ToList();
+            ImageFilesD = fileNames.Where(name => Path.GetFileName(name).Contains("D")).Select(name => new ImageFile(name)).ToList();
 
             CurrentImageFileA = ImageFilesA.FirstOrDefault();
             CurrentImageFileB = ImageFilesB.FirstOrDefault();


### PR DESCRIPTION
フルパスを基準にフィルタリングを行っていたため、
当初の想定であるファイル名基準でフィルタリングがされるよう修正
close #1
